### PR TITLE
Fix for StreamDeck 6.5-onwards (Change of dialPress to dialDown/dialUp)

### DIFF
--- a/dist/manifest.json
+++ b/dist/manifest.json
@@ -187,7 +187,7 @@
   "Name": "Discord Volume Mixer",
   "Icon": "icons/icons8_discord_new_72px",
   "URL": "https://github.com/CZDanol/StreamDeck-DiscordVolumeMixer2",
-  "Version": "2.0.1.8",
+  "Version": "2.0.1.9",
   "Profiles": [
     {
       "Name": "Discord Volume Mixer",
@@ -222,6 +222,6 @@
     }
   ],
   "Software": {
-    "MinimumVersion": "5"
+    "MinimumVersion": "6.1"
   }
 }

--- a/src/dvmplugin.cpp
+++ b/src/dvmplugin.cpp
@@ -236,7 +236,7 @@ void DVMPlugin::onStreamDeckEventReceived(const QStreamDeckEvent &e) {
 	using ET = QStreamDeckEvent::EventType;
 
 	// Try connecting to discord whenever any button is pressed
-	if(!discord.isConnected() && !discordConnectTimeoutTimer_.isActive() && (e.eventType == ET::touchTap || e.eventType == ET::keyDown || e.eventType == ET::dialPress || e.eventType == ET::dialRotate)) {
+	if(!discord.isConnected() && !discordConnectTimeoutTimer_.isActive() && (e.eventType == ET::touchTap || e.eventType == ET::keyDown || e.eventType == ET::dialDown || e.eventType == ET::dialUp || e.eventType == ET::dialRotate)) {
 		discordConnectTimeoutTimer_.start();
 		connectToDiscord();
 	}


### PR DESCRIPTION
StreamDeck 6.1 split the event dialPress into dialDown/dialUp and deprecrated dialPress, after 6.5 dialPress was fully deleted. To maintain compatibility with modern StreamDeck versions I reflected this change in the code.

**This breaks compatibility pre-6.1**